### PR TITLE
Published to Azure App Service without a container

### DIFF
--- a/.github/workflows/SzBlazor1.yml
+++ b/.github/workflows/SzBlazor1.yml
@@ -1,0 +1,48 @@
+name: Build and deploy .NET Core application to Web App SzBlazor1
+on:
+  push:
+    branches:
+    - master
+env:
+  AZURE_WEBAPP_NAME: SzBlazor1
+  AZURE_WEBAPP_PACKAGE_PATH: Sz.Blazor/published
+  CONFIGURATION: Release
+  DOTNET_CORE_VERSION: 8.0.x
+  WORKING_DIRECTORY: Sz.Blazor
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: ${{ env.DOTNET_CORE_VERSION }}
+    - name: Restore
+      run: dotnet restore "${{ env.WORKING_DIRECTORY }}"
+    - name: Build
+      run: dotnet build "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-restore
+    - name: Test
+      run: dotnet test "${{ env.WORKING_DIRECTORY }}" --no-build
+    - name: Publish
+      run: dotnet publish "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-build --output "${{ env.AZURE_WEBAPP_PACKAGE_PATH }}"
+    - name: Publish Artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: webapp
+        path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - name: Download artifact from build job
+      uses: actions/download-artifact@v3
+      with:
+        name: webapp
+        path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+    - name: Deploy to Azure WebApp
+      uses: azure/webapps-deploy@v2
+      with:
+        app-name: ${{ env.AZURE_WEBAPP_NAME }}
+        publish-profile: ${{ secrets.SzBlazor1_0827 }}
+        package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}

--- a/.github/workflows/SzBlazor1.yml
+++ b/.github/workflows/SzBlazor1.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - master
+    - azure-c
 env:
   AZURE_WEBAPP_NAME: SzBlazor1
   AZURE_WEBAPP_PACKAGE_PATH: Sz.Blazor/published


### PR DESCRIPTION
FYI This link you mentioned above about publishing a container seems to be about targeting a preview runtime, which I am not doing (using 8.0.203 SDK) .  But maybe you thought it covered using a container by analogy?  I don't think it is useful after reading through it.  https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/azure-apps/?view=aspnetcore-8.0&tabs=visual-studio#use-docker-with-web-apps-for-containers

Containerizing my app was easy.   csharpfritz you were assuming I'd publish my container as an "Azure App Service Container", right?   I tried that and ran into this issue: https://stackoverflow.com/questions/78176654/docker-support-must-be-enabled-in-trying-to-publish-to-azure-app-service-conta

This looks like the main doc for publishing, but it isn't for containers: https://learn.microsoft.com/en-us/aspnet/core/tutorials/publish-to-azure-webapp-using-vs?view=aspnetcore-8.0#deploy-the-app-to-azure

But deploying via a GH Action without a container worked great, so I'm going with that for now. 🙂 
Stack Overflow
["Docker support must be enabled" in trying to publish to Azure App ...](https://stackoverflow.com/questions/78176654/docker-support-must-be-enabled-in-trying-to-publish-to-azure-app-service-conta)
In a new "Hello World" Blazor Web App in .NET 8 (with SDK 8.0.202 and VS Pro), after adding Docker Support with the .NET SDK container build type...

From https://discordapp.com/channels/389226088607252490/555059772517384192/1219014776991252603